### PR TITLE
Issue 60, 62 related fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ LABEL description="A simple HTTP service."
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+ENV HOME=/httpbin
+
+WORKDIR /httpbin
 
 RUN apt update -y && apt install python3-pip libssl-dev libffi-dev git -y && pip3 install --no-cache-dir pipenv
 
-WORKDIR /httpbin
 ADD . .
 RUN pipenv sync
 


### PR DESCRIPTION
Build process creates /root/.local folder but for running as non root (and maybe some similar usecases) it would be best in my opinion that the virtualenvs resides under the workdir /httpbin e.g. /httpbin/.local/.../virtualenvs/

This one line fixes my usage of runAsUser <anyNonRootUser>
**This is also related and should solve the root cause of both issue 60 and issue 62.**
### Summary

Adding the HOME variable makes the Docker build process create and use the /httpbin/.local folder in both build and runtime. Without this, the Dockerfile creates a folder /root/.local and uses it while the specified user is root. However, in the case of a user override with runAsUser or a similar command, /root is no longer the home directory and is not accessible to the non-root user. This line fixes this issue. It has been fixed and tested locally.

### Full changelog

Dockerfile
* added line: ENV HOME=/httpbin
* changed placement WORKDIR /httpbin


### Issues resolved

Fix 60, 62

### Documentation

- [ ]

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Docker
- [ ] Manual testing on Kubernetes


Test results:
**TEST 1: Reproducing the `Permission denied: '/.local'` issue**
![image](https://github.com/user-attachments/assets/63afb60d-7b02-4d5f-bfb2-6b6814991cd2)

**Test 2: Reproducing the `Error: the command gunicorn could not be found within PATH or Pipfile's [scripts].`**
![image](https://github.com/user-attachments/assets/d901b00c-ecd7-44ab-89eb-acdf97ca1525)

**Test 3: After fix**
![image](https://github.com/user-attachments/assets/e5e9c8e5-f0c8-45ca-862d-0673446bd563)


