### PR TITLE
Use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20240808
+FROM ubuntu:jammy
 
 LABEL name="httpbin"
 LABEL description="A simple HTTP service."
@@ -9,11 +9,30 @@ ENV HOME=/httpbin
 
 WORKDIR /httpbin
 
-RUN apt update -y && apt install python3-pip libssl-dev libffi-dev git -y && pip3 install --no-cache-dir pipenv
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    httpbin
+
+RUN chown httpbin /httpbin
+RUN chmod u+rwx /httpbin
+
+RUN apt-get update -y && apt-get install python3-pip libssl-dev libffi-dev git libcap2-bin -y
 
 ADD . .
-RUN pipenv sync
 
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/python3.10
 EXPOSE 80
+
+USER httpbin
+ENV PATH="/httpbin/.local/bin:$PATH"
+
+RUN pip3 install --no-cache-dir pipenv
+RUN pipenv sync
 
 CMD ["pipenv", "run", "gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]


### PR DESCRIPTION
should be a drop-in replacement

```bash
$ podman run -p 80:80 httpbin
[2025-01-08 00:57:21 +0000] [1] [INFO] Starting gunicorn 21.2.0
[2025-01-08 00:57:21 +0000] [1] [INFO] Listening at: http://0.0.0.0:80 (1)
[2025-01-08 00:57:21 +0000] [1] [INFO] Using worker: gevent
[2025-01-08 00:57:21 +0000] [3] [INFO] Booting worker with pid: 3
^C[2025-01-08 00:57:22 +0000] [1] [INFO] Handling signal: int
[2025-01-08 00:57:22 +0000] [3] [INFO] Worker exiting (pid: 3)
[2025-01-08 00:57:22 +0000] [1] [INFO] Shutting down: Master
```