### PR TITLE
Add attest

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,4 +5,8 @@ target "build" {
   context = "./"
   dockerfile = "Dockerfile"
   platforms = ["linux/amd64", "linux/arm64"]
+  attest = [
+    "type=sbom,generator=docker/scout-sbom-indexer:latest",
+    "type=provenance"
+  ]
 }


### PR DESCRIPTION
### Summary

Add `attest` to build to address "missing supply chain attestations"
