### PR TITLE
Add source for new bake action restriction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,9 @@ jobs:
     - name: Setup buildx
       uses: docker/setup-buildx-action@v3
     - name: Build Only
-      uses: docker/bake-action@v6
+      uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6
       with:
+        source: .
         files: |
           ./docker-bake.hcl
         targets: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,9 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build & Push
-      uses: docker/bake-action@v6
+      uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6
       with:
+        source: .
         push: 'true'
         files: |
           ./docker-bake.hcl


### PR DESCRIPTION
dependabot bump of course ignored release notes warning https://github.com/docker/bake-action/releases/tag/v6.0.0
